### PR TITLE
Bugfix, for error in `posterior_at_ages` whenever `extant_prob = FALSE`.

### DIFF
--- a/R/posterior_at_ages.R
+++ b/R/posterior_at_ages.R
@@ -107,7 +107,7 @@ get_extant_binary_network <- function(dat, tree, host_tree, state, drop_empty) {
     s <- as.numeric(stringr::str_split(dat_it$end_state[i], "")[[1]])
     s_idx <- s %in% state
 
-    m_sample[it_idx, n_idx, s_idx] <- state
+    m_sample[1, n_idx, s_idx] <- state
     m_posterior[n_idx, s_idx] <- m_posterior[n_idx, s_idx] + 1
   }
 


### PR DESCRIPTION
`get_binary_extant_network` does not loop over MCMC iterations, so `it_idx` does not exist. Save in first entry instead.